### PR TITLE
feat: expand per-page SEO metadata and LLM discoverability

### DIFF
--- a/next-sitemap.config.js
+++ b/next-sitemap.config.js
@@ -4,4 +4,22 @@ module.exports = {
   generateRobotsTxt: true,
   trailingSlash: false,
   generateIndexSitemap: false,
+  robotsTxtOptions: {
+    policies: [
+      { userAgent: "*", allow: "/" },
+      { userAgent: "GPTBot", allow: "/" },
+      { userAgent: "ChatGPT-User", allow: "/" },
+      { userAgent: "OAI-SearchBot", allow: "/" },
+      { userAgent: "ClaudeBot", allow: "/" },
+      { userAgent: "Claude-Web", allow: "/" },
+      { userAgent: "anthropic-ai", allow: "/" },
+      { userAgent: "PerplexityBot", allow: "/" },
+      { userAgent: "Google-Extended", allow: "/" },
+      { userAgent: "CCBot", allow: "/" },
+      { userAgent: "Applebot-Extended", allow: "/" },
+      { userAgent: "Bytespider", allow: "/" },
+      { userAgent: "Amazonbot", allow: "/" },
+      { userAgent: "Meta-ExternalAgent", allow: "/" },
+    ],
+  },
 }

--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -12,19 +12,50 @@ import JsonLd from "@/components/seo/JsonLd"
 import { siteConfig } from "@/data/site"
 import career from "@/data/career"
 
+const aboutDescription =
+  "CTO with 10+ years of experience leading technology teams, reducing IT costs, and building scalable fintech platforms."
+
 export const metadata: Metadata = {
   title: "About",
-  description:
-    "CTO with 10+ years of experience leading technology teams, reducing IT costs, and building scalable fintech platforms.",
+  description: aboutDescription,
+  keywords: [
+    "Lorenzo De Francesco",
+    "CTO",
+    "Chief Technology Officer",
+    "About Lorenzo De Francesco",
+    "fintech leader",
+    "tech leadership",
+    "IT governance",
+    "cloud architecture",
+    "team building",
+    "Azimut Marketplace CTO",
+    "engineering manager",
+    "IT cost optimization",
+  ],
   alternates: {
     canonical: `${siteConfig.url}/about`,
   },
   openGraph: {
     title: `About | ${siteConfig.name}`,
-    description:
-      "CTO with 10+ years of experience leading technology teams, reducing IT costs, and building scalable fintech platforms.",
+    description: aboutDescription,
     url: `${siteConfig.url}/about`,
+    siteName: siteConfig.name,
+    locale: "en_US",
     type: "profile",
+    images: [
+      {
+        url: siteConfig.image,
+        width: 800,
+        height: 800,
+        alt: `${siteConfig.name} - ${siteConfig.title}`,
+      },
+    ],
+  },
+  twitter: {
+    card: "summary_large_image",
+    title: `About | ${siteConfig.name}`,
+    description: aboutDescription,
+    images: [siteConfig.image],
   },
 }
 

--- a/src/app/about/tech/page.tsx
+++ b/src/app/about/tech/page.tsx
@@ -10,12 +10,56 @@ import JsonLd from "@/components/seo/JsonLd"
 import { siteConfig } from "@/data/site"
 import techStack from "@/data/tech-stack"
 
+const techDescription =
+  "Full stack expertise: React, Java, Node.js, Kubernetes, AWS, Azure, and more. 10+ years of hands-on development experience."
+
 export const metadata: Metadata = {
   title: "Tech Skills",
-  description:
-    "Full stack expertise: React, Java, Node.js, Kubernetes, AWS, Azure, and more. 10+ years of hands-on development experience.",
+  description: techDescription,
+  keywords: [
+    "Lorenzo De Francesco",
+    "tech skills",
+    "full stack developer",
+    "React",
+    "Next.js",
+    "TypeScript",
+    "Java",
+    "Spring Boot",
+    "Node.js",
+    "Kubernetes",
+    "Docker",
+    "AWS",
+    "Azure",
+    "GCP",
+    "Terraform",
+    "microservices",
+    "cloud architecture",
+    "DevOps",
+  ],
   alternates: {
     canonical: `${siteConfig.url}/about/tech`,
+  },
+  openGraph: {
+    title: `Tech Skills | ${siteConfig.name}`,
+    description: techDescription,
+    url: `${siteConfig.url}/about/tech`,
+    siteName: siteConfig.name,
+    locale: "en_US",
+    type: "profile",
+    images: [
+      {
+        url: siteConfig.image,
+        width: 800,
+        height: 800,
+        alt: `${siteConfig.name} - Tech Skills`,
+      },
+    ],
+  },
+  twitter: {
+    card: "summary_large_image",
+    title: `Tech Skills | ${siteConfig.name}`,
+    description: techDescription,
+    images: [siteConfig.image],
   },
 }
 

--- a/src/app/events/[id]/page.tsx
+++ b/src/app/events/[id]/page.tsx
@@ -24,17 +24,44 @@ export async function generateMetadata({
   const { id } = await params
   const event = events.find((e) => e.slug === id)
   if (!event) return {}
+  const description =
+    event.shortDescription || event.description?.slice(0, 160)
+  const keywords = [
+    event.title,
+    "Lorenzo De Francesco",
+    "tech talk",
+    "speaking",
+    event.isOnline ? "online event" : "in-person event",
+    ...(event.venue ? [event.venue] : []),
+    ...(event.podcast ? ["podcast"] : []),
+    ...(event.video ? ["video", "recording"] : []),
+    "conference",
+  ]
   return {
     title: event.title,
-    description:
-      event.shortDescription || event.description?.slice(0, 160),
+    description,
+    keywords,
     alternates: {
       canonical: `${siteConfig.url}/events/${id}`,
     },
     openGraph: {
       title: `${event.title} | ${siteConfig.name}`,
-      description: event.shortDescription || event.description?.slice(0, 160),
+      description,
       url: `${siteConfig.url}/events/${id}`,
+      siteName: siteConfig.name,
+      locale: "en_US",
+      type: "article",
+      images: [
+        {
+          url: event.image,
+          alt: event.title,
+        },
+      ],
+    },
+    twitter: {
+      card: "summary_large_image",
+      title: `${event.title} | ${siteConfig.name}`,
+      description,
       images: [event.image],
     },
   }

--- a/src/app/events/page.tsx
+++ b/src/app/events/page.tsx
@@ -9,12 +9,50 @@ import JsonLd from "@/components/seo/JsonLd"
 import { siteConfig } from "@/data/site"
 import events from "@/data/events"
 
+const eventsDescription =
+  "Speaking engagements, conference talks, panels, and webinars on fintech, cloud, and IT management."
+
 export const metadata: Metadata = {
   title: "Events",
-  description:
-    "Speaking engagements, conference talks, panels, and webinars on fintech, cloud, and IT management.",
+  description: eventsDescription,
+  keywords: [
+    "Lorenzo De Francesco",
+    "tech speaker",
+    "conference speaker",
+    "fintech conference",
+    "cloud conference",
+    "IT management talks",
+    "webinars",
+    "panels",
+    "podcasts",
+    "developer events",
+    "Google Developer Group Milano",
+    "keynote speaker",
+  ],
   alternates: {
     canonical: `${siteConfig.url}/events`,
+  },
+  openGraph: {
+    title: `Events | ${siteConfig.name}`,
+    description: eventsDescription,
+    url: `${siteConfig.url}/events`,
+    siteName: siteConfig.name,
+    locale: "en_US",
+    type: "website",
+    images: [
+      {
+        url: siteConfig.image,
+        width: 800,
+        height: 800,
+        alt: `${siteConfig.name} - Events & Talks`,
+      },
+    ],
+  },
+  twitter: {
+    card: "summary_large_image",
+    title: `Events | ${siteConfig.name}`,
+    description: eventsDescription,
+    images: [siteConfig.image],
   },
 }
 

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -108,6 +108,18 @@ export default function RootLayout({
   return (
     <html lang="en" className={`${outfit.variable} ${nunito.variable}`}>
       <head>
+        <link
+          rel="alternate"
+          type="text/markdown"
+          href="/llms.txt"
+          title="LLM-friendly summary"
+        />
+        <link
+          rel="alternate"
+          type="text/markdown"
+          href="/llms-full.txt"
+          title="LLM-friendly full profile"
+        />
         <JsonLd
           data={{
             "@context": "https://schema.org",

--- a/src/app/not-found.tsx
+++ b/src/app/not-found.tsx
@@ -1,5 +1,32 @@
+import type { Metadata } from "next"
 import Link from "next/link"
 import PageWrapper from "@/components/layout/PageWrapper"
+import { siteConfig } from "@/data/site"
+
+export const metadata: Metadata = {
+  title: "Page Not Found",
+  description:
+    "The page you are looking for does not exist. Head back to the home page to keep exploring.",
+  robots: {
+    index: false,
+    follow: false,
+  },
+  openGraph: {
+    title: `Page Not Found | ${siteConfig.name}`,
+    description:
+      "The page you are looking for does not exist. Head back to the home page to keep exploring.",
+    url: siteConfig.url,
+    siteName: siteConfig.name,
+    locale: "en_US",
+    type: "website",
+  },
+  twitter: {
+    card: "summary",
+    title: `Page Not Found | ${siteConfig.name}`,
+    description:
+      "The page you are looking for does not exist. Head back to the home page to keep exploring.",
+  },
+}
 
 export default function NotFound() {
   return (

--- a/src/app/projects/[id]/page.tsx
+++ b/src/app/projects/[id]/page.tsx
@@ -23,17 +23,44 @@ export async function generateMetadata({
   const { id } = await params
   const project = projects.find((p) => p.slug === id)
   if (!project) return {}
+  const description =
+    project.boxDescription || project.description?.slice(0, 160)
+  const keywords = [
+    project.title,
+    ...(project.category ?? []),
+    ...(project.stack ?? []),
+    "Lorenzo De Francesco",
+    "project",
+    "portfolio",
+    "case study",
+  ]
+  const image = project.image ?? siteConfig.image
   return {
     title: project.title,
-    description: project.boxDescription || project.description?.slice(0, 160),
+    description,
+    keywords,
     alternates: {
       canonical: `${siteConfig.url}/projects/${id}`,
     },
     openGraph: {
       title: `${project.title} | ${siteConfig.name}`,
-      description: project.boxDescription || project.description?.slice(0, 160),
+      description,
       url: `${siteConfig.url}/projects/${id}`,
-      ...(project.image && { images: [project.image] }),
+      siteName: siteConfig.name,
+      locale: "en_US",
+      type: "article",
+      images: [
+        {
+          url: image,
+          alt: project.title,
+        },
+      ],
+    },
+    twitter: {
+      card: "summary_large_image",
+      title: `${project.title} | ${siteConfig.name}`,
+      description,
+      images: [image],
     },
   }
 }

--- a/src/app/projects/page.tsx
+++ b/src/app/projects/page.tsx
@@ -11,12 +11,52 @@ import JsonLd from "@/components/seo/JsonLd"
 import { siteConfig } from "@/data/site"
 import projects from "@/data/projects"
 
+const projectsDescription =
+  "Open source tools and a selection of fintech, insurtech, and enterprise projects built over 10+ years of software development."
+
 export const metadata: Metadata = {
   title: "Projects",
-  description:
-    "Open source tools and a selection of fintech, insurtech, and enterprise projects built over 10+ years of software development.",
+  description: projectsDescription,
+  keywords: [
+    "Lorenzo De Francesco projects",
+    "open source",
+    "MFE Orchestrator",
+    "Swagger Aggregator",
+    "microfrontends",
+    "fintech projects",
+    "insurtech projects",
+    "crypto projects",
+    "enterprise software",
+    "Kubernetes",
+    "React",
+    "Node.js",
+    "portfolio",
+    "software portfolio",
+  ],
   alternates: {
     canonical: `${siteConfig.url}/projects`,
+  },
+  openGraph: {
+    title: `Projects | ${siteConfig.name}`,
+    description: projectsDescription,
+    url: `${siteConfig.url}/projects`,
+    siteName: siteConfig.name,
+    locale: "en_US",
+    type: "website",
+    images: [
+      {
+        url: siteConfig.image,
+        width: 800,
+        height: 800,
+        alt: `${siteConfig.name} - Projects`,
+      },
+    ],
+  },
+  twitter: {
+    card: "summary_large_image",
+    title: `Projects | ${siteConfig.name}`,
+    description: projectsDescription,
+    images: [siteConfig.image],
   },
 }
 


### PR DESCRIPTION
## Summary
- Add `keywords`, `openGraph` and `twitter` metadata to About, About/Tech, Projects (list + detail), Events (list + detail) and Not Found pages
- Make `openGraph`/`twitter` on dynamic project and event pages fall back to the site image and include full `siteName`/`locale`/`type`
- Add `llms.txt` / `llms-full.txt` alternate links in the root layout head so LLMs can discover the markdown summary
- Allow known AI crawlers (GPTBot, ChatGPT-User, OAI-SearchBot, ClaudeBot, Claude-Web, anthropic-ai, PerplexityBot, Google-Extended, CCBot, Applebot-Extended, Bytespider, Amazonbot, Meta-ExternalAgent) in the `next-sitemap`-generated `robots.txt`

JSON-LD structured data was already present on every page (Person, ProfilePage, CollectionPage, CreativeWork, Event, BreadcrumbList, WebSite) and has been left untouched.

## Test plan
- [x] `pnpm build` succeeds (62 static pages generated)
- [x] `robots.txt` includes the AI crawler allowances after `postbuild`
- [ ] After deploy, validate pages with Google Rich Results Test and the Twitter/OG debuggers
- [ ] Verify `/llms.txt` and `/llms-full.txt` are reachable in production

https://claude.ai/code/session_01CRKHH8oDi82XhS4QK9hciq